### PR TITLE
Fix scaffold

### DIFF
--- a/lib/widgets/shipanther_scaffold.dart
+++ b/lib/widgets/shipanther_scaffold.dart
@@ -46,9 +46,7 @@ class ShipantherScaffold extends StatelessWidget {
         centerTitle: true,
       ),
       body: SafeArea(
-        child: SingleChildScrollView(
-          child: body,
-        ),
+        child: body,
       ),
       floatingActionButton: floatingActionButton,
       drawer: (user == null)


### PR DESCRIPTION
## Description
Remove SingleChildScrollView as inner screens don't render when it is set on the scaffold.
This also means that the login page would not scroll on a small screen but this should ideally be
fixed across the board with a consistent strategy. Requires some research on how to do this in flutter.

